### PR TITLE
Add support for RHEL7 and RHEL8

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ This role has been tested on these [container images](https://hub.docker.com/):
 |debian|latest|no|
 |centos|7|no|
 |centos|latest|no|
+|redhat|7|no|
+|redhat|latest|no|
 |fedora|latest|no|
 |fedora|rawhide|yes|
 |opensuse|latest|no|

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -13,6 +13,9 @@ _firewall_packages:
     CentOS-7:
       - ufw
     CentOS-8: []
+    RedHat-7:
+      - ufw
+    RedHat-8: []
     Fedora:
       - ufw
     openSUSE Leap:
@@ -27,6 +30,12 @@ _firewall_packages:
       - iptables
       - iptables-services
     CentOS-8:
+      - firewalld
+    RedHat-7:
+      - firewalld
+      - iptables
+      - iptables-services
+    RedHat-8:
       - firewalld
     Fedora:
       - firewalld
@@ -43,6 +52,8 @@ _firewall_service:
   Alpine: iptables
   CentOS-7: firewalld
   CentOS-8: firewalld
+  RedHat-7: firewalld
+  RedHat-8: firewalld
   Fedora: firewalld
   openSUSE Leap: firewalld
 


### PR DESCRIPTION
---
name: Add support for RHEL7 and RHEL8
about: Add support for RHEL7 and RHEL8 to main.yml

---

**Describe the change**
Previously, this role only referenced CentOS7 and CentOS8 by their ansible_distribution name "CentOS", which does not match the ansible_distribution name for RHEL7 and RHEL8, which is "RedHat". This pull request fixes that, adding support for those distributions.

(Which I need for some upcoming large scale event next week! :) )

**Testing**
I ran this module a couple of times against a set of RHEL8 machines, giving no problems whatsoever.
