### PR TITLE
Allow adding a select interface to a selected zone.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,42 @@ firewall_services:
 #     protocol: tcp
 #   - name: 1337
 #     state: absent
+
+# A list of interfaces you would like to add/remove to/from a zone in firewalld.
+# firewall_interfaces: []
+
+# examples:
+# firewall_interfaces:
+#   - interface: eth0
+#     zone: trusted
+#   - type: bond
+#     interface: bond0
+#     zone: trusted
+#   - interface: ens0
+#     zone: trusted
+#     state: disabled
+
 ```
 
 ## [Requirements](#requirements)
 
 - pip packages listed in [requirements.txt](https://github.com/robertdebock/ansible-role-firewall/blob/master/requirements.txt).
+
+- Feature [Allow adding a select interface to a selected zone.](https://github.com/robertdebock/ansible-role-firewall/issues/4) is only supported on operating systems with firewalld as default firewall software.
+  For details see manpage _firewalld.zones(5)_ "How to set or change a zone for a connection?".
+  This feature will only be usable if the interface is managed by NetworkManager.
+  Suse os-family needs to switch from wicked to NetworkManager, RedHat os-family is using NetworkManger by default.
+  [Requires installing additional packages](https://docs.ansible.com/ansible/latest/collections/community/general/nmcli_module.html#synopsis) otherwise tasks for the feature will be skipped.
+
+    - known issue: collection `community.general is version('3.3.0', '>=')` and `ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('30', '<=')`.
+
+      - _reason_: those versions [pulled in new settings](https://github.com/ansible-collections/community.general/pull/2732/checks) see `routing-rules` in [nm-settings](https://developer-old.gnome.org/NetworkManager/stable/nm-settings-nmcli.html).
+
+        _workarround_: use collection `community.general` version `3.2.0` but this will introduce different issues. therefore  fedora<=30 not supported
+        
+            # on centos7,fedora29,rhel7
+            CRITICAL Idempotence test failed because of the following tasks:
+            *  => ansible-role-firewall : add interface to a zone (networkmanager)
 
 ## [Status of used roles](#status-of-requirements)
 
@@ -89,7 +120,7 @@ This role has been tested on these [container images](https://hub.docker.com/u/r
 |container|tags|
 |---------|----|
 |alpine|all|
-|el|8|
+|el|7,8|
 |debian|all|
 |fedora|all|
 |opensuse|all|

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,3 +21,17 @@ firewall_services:
 #     protocol: tcp
 #   - name: 1337
 #     state: absent
+
+# A list of interfaces you would like to add/remove to/from a zone in firewalld.
+# firewall_interfaces: []
+
+# examples:
+# firewall_interfaces:
+#   - interface: eth0
+#     zone: trusted
+#   - type: bond
+#     interface: bond0
+#     zone: trusted
+#   - interface: ens0
+#     zone: trusted
+#     state: disabled

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,3 +12,11 @@
 - name: reload firewalld
   ansible.builtin.command:
     cmd: firewall-cmd --reload
+
+- name: restart NetworkManager
+  ansible.builtin.service:
+    name: NetworkManager
+    state: restarted
+  when:
+    - ansible_connection not in [ "container", "docker", "community.docker.docker" ]
+    - not ansible_check_mode | bool

--- a/molecule/physical/INSTALL.rst
+++ b/molecule/physical/INSTALL.rst
@@ -1,0 +1,72 @@
+*******
+Delegated driver installation guide
+*******
+
+Requirements
+============
+
+Machines are pre-provisioned and externally managed via vagrant. Boxes are taken from https://roboxes.org/
+
+Install
+=======
+
+* install vagrant
+* vagrant boxes
+    ```shell
+    vagrant box add generic/alma8
+    vagrant box add generic/centos7
+    vagrant box add generic/centos8
+    vagrant box add generic/fedora28
+    vagrant box add generic/fedora29
+    vagrant box add generic/fedora35
+    vagrant box add generic/opensuse15
+    vagrant box add generic/rhel7
+    vagrant box add generic/rhel8
+    ```
+* create vagrant environment
+    ```shell
+    vagrant up
+    ```
+* export ssh config
+    ```shell
+    vagrant ssh-config > molecule/physical/ssh_config
+    ```
+* copy and change permissions on identityfiles.
+    ```shell
+    VAGRANTFILE_BASEDIR=/mnt/c/Users/Public/Documents/EL
+    pushd molecule/physical/.ssh
+    for file in $(ls -1 "${VAGRANTFILE_BASEDIR}/.vagrant/machines/"*"/"*"/private_key")
+    do
+    cp -v "$file" "$(basename $(dirname $(dirname $file)))"
+    chmod 0600 "$(basename $(dirname $(dirname $file)))"
+    done
+    ```
+* edit the path of IdentityFile property in ssh_config
+
+Access hosts
+------------
+
+ssh to all hosts:
+
+    for host in $(\grep -Po '^Host\s+\K.*'  molecule/physical/ssh_config); do echo $host ; ssh -X -F molecule/physical/ssh_config $host ; done
+
+
+Details 
+-------
+
+vagrant providers
+~~~~~~~~~~~~~~~~
+
+* hyper-v
+
+this is on windows desktop with hyper-v virtualization and ansible running inside WSL.
+forwarding needs to be setup between the different switches:
+
+    Get-NetIPInterface | where {$_.InterfaceAlias -eq 'vEthernet (WSL)' -or $_.InterfaceAlias -eq 'vEthernet (Default Switch)'} | Set-NetIPInterface -Forwarding Enabled
+
+vagrant image
+~~~~~~~~~~~~~
+
+* generic/opensuse15
+
+this image has some updating issues. it maybe required to login once and run: `sudo zypper ref && sudo zypper up && sudo reboot`

--- a/molecule/physical/Vagrantfile
+++ b/molecule/physical/Vagrantfile
@@ -1,0 +1,29 @@
+Vagrant.configure("2") do |config|
+    config.vm.define "alma8" do |alma8|
+      alma8.vm.box = "generic/alma8"
+    end
+    config.vm.define "centos7" do |centos7|
+      centos7.vm.box = "generic/centos7"
+    end
+    config.vm.define "centos8" do |centos8|
+      centos8.vm.box = "generic/centos8"
+    end
+    # config.vm.define "fedora28" do |fedora28|
+    #   fedora28.vm.box = "generic/fedora28"
+    # end
+    # config.vm.define "fedora29" do |fedora29|
+    #   fedora29.vm.box = "generic/fedora29"
+    # end
+    config.vm.define "fedora35" do |fedora35|
+      fedora35.vm.box = "generic/fedora35"
+    end
+    config.vm.define "opensuse15" do |opensuse15|
+      opensuse15.vm.box = "generic/opensuse15"
+    end
+    config.vm.define "rhel7" do |rhel7|
+      rhel7.vm.box = "generic/rhel7"
+    end
+    config.vm.define "rhel8" do |rhel8|
+      rhel8.vm.box = "generic/rhel8"
+    end
+  end

--- a/molecule/physical/create.yml
+++ b/molecule/physical/create.yml
@@ -1,0 +1,36 @@
+---
+- name: Create
+  # hosts: localhost
+  hosts: all
+  # connection: local
+  gather_facts: false
+  # no_log: "{{ molecule_no_log }}"
+  # tasks:
+
+  #   # TODO: Developer must implement and populate 'server' variable
+
+  #   - when: server.changed | default(false) | bool
+  #     block:
+  #       - name: Populate instance config dict
+  #         set_fact:
+  #           instance_conf_dict: {
+  #             'instance': "{{ }}",
+  #             'address': "{{ }}",
+  #             'user': "{{ }}",
+  #             'port': "{{ }}",
+  #             'identity_file': "{{ }}", }
+  #         with_items: "{{ server.results }}"
+  #         register: instance_config_dict
+
+  #       - name: Convert instance config dict to a list
+  #         set_fact:
+  #           instance_conf: "{{ instance_config_dict.results | map(attribute='ansible_facts.instance_conf_dict') | list }}"
+
+  #       - name: Dump instance config
+  #         copy:
+  #           content: |
+  #             # Molecule managed
+
+  #             {{ instance_conf | to_json | from_json | to_yaml }}
+  #           dest: "{{ molecule_instance_config }}"
+  #           mode: 0600

--- a/molecule/physical/destroy.yml
+++ b/molecule/physical/destroy.yml
@@ -1,0 +1,25 @@
+---
+- name: Destroy
+  # hosts: localhost
+  hosts: all
+  # connection: local
+  gather_facts: false
+  # no_log: "{{ molecule_no_log }}"
+  # tasks:
+  #   # Developer must implement.
+
+  #   # Mandatory configuration for Molecule to function.
+
+  #   - name: Populate instance config
+  #     set_fact:
+  #       instance_conf: {}
+
+  #   - name: Dump instance config
+  #     copy:
+  #       content: |
+  #         # Molecule managed
+
+  #         {{ instance_conf | to_json | from_json | to_yaml }}
+  #       dest: "{{ molecule_instance_config }}"
+  #       mode: 0600
+  #     when: server.changed | default(false) | bool

--- a/molecule/physical/molecule.yml
+++ b/molecule/physical/molecule.yml
@@ -1,0 +1,37 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: requirements.yml
+    requirements-file: requirements.yml
+driver:
+  name: delegated
+  options:
+    managed: False
+    login_cmd_template: 'ssh {instance} -F "${MOLECULE_SCENARIO_DIRECTORY}/ssh_config"'
+    ansible_connection_options:
+      ansible_connection: ssh
+      ansible_ssh_common_args: '-F "${MOLECULE_SCENARIO_DIRECTORY}/ssh_config"'
+platforms:
+  - name: alma8
+  - name: centos7
+  - name: centos8
+  # - name: fedora28
+  # - name: fedora29
+  - name: fedora35
+  - name: opensuse15
+  - name: rhel7
+  - name: rhel8
+provisioner:
+  name: ansible
+  playbooks:
+    # prepare: ../default/prepare.yml
+    converge: ../default/converge.yml
+  default_sequence:
+    - converge
+  test_sequence:
+    # - prepare
+    - converge
+    # - verify
+  verify_sequence:
+    - converge

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -64,3 +64,25 @@
   when:
     - firewall_services is defined
     - item.state is defined
+
+- name: test if firewall_interfaces is set correctly
+  ansible.builtin.assert:
+    that:
+      - firewall_interfaces is iterable
+    quiet: yes
+  when:
+    - firewall_interfaces is defined
+
+- name: test if item in firewall_interfaces is set correctly
+  ansible.builtin.assert:
+    that:
+      - item.interface is defined
+      - item.interface is string
+      - item.zone is defined
+      - item.zone is string
+    quiet: yes
+  loop: "{{ firewall_interfaces }}"
+  loop_control:
+    label: "{{ item.interface }}"
+  when:
+    - firewall_interfaces is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -147,3 +147,115 @@
   when:
     - ansible_connection not in [ "container", "docker", "community.docker.docker" ]
     - firewall_service is defined
+
+# [Allow adding a select interface to a selected zone](https://github.com/robertdebock/ansible-role-firewall/issues/4)
+- name: |
+    feature | Allow adding a select interface to a selected zone
+      check requirements
+  when:
+    - firewall_service == "firewalld"
+    - firewall_packages_firewalld_nm_fix is defined
+    - firewall_packages_firewalld_nm_fix is iterable
+    - firewall_packages_firewalld_nm_fix|length > 0
+    - firewall_interfaces is defined
+    - firewall_interfaces is iterable
+    - firewall_interfaces|length > 0
+
+  block:
+
+    - name: check networkmanager software
+      ansible.builtin.package:
+        name: "{{ firewall_packages_firewalld_nm_fix }}"
+        state: present
+      check_mode: true
+      changed_when: false
+      register: _firewall_networkmanager_installed
+
+    - name: check networkmanager service running
+      ansible.builtin.systemd:
+        state: started
+        name: NetworkManager
+      check_mode: true
+      changed_when: false
+      ignore_errors: true
+      register: _firewall_networkmanager_service_running
+
+# [Allow adding a select interface to a selected zone](https://github.com/robertdebock/ansible-role-firewall/issues/4)
+- name: |
+    feature | Allow adding a select interface to a selected zone
+      changes
+  when:
+    - _firewall_networkmanager_installed is defined
+    - ( ansible_os_family == 'Suse' and _firewall_networkmanager_installed.state is defined and _firewall_networkmanager_installed.state == 'present' )
+      or (_firewall_networkmanager_installed.msg is defined and _firewall_networkmanager_installed.msg == "Nothing to do")
+      or (_firewall_networkmanager_installed.results is defined and _firewall_networkmanager_installed.results is iterable and (_firewall_networkmanager_installed.results|length > 0))
+    - _firewall_networkmanager_service_running is defined
+    - _firewall_networkmanager_service_running.status is defined
+    - _firewall_networkmanager_service_running.status.ActiveState is defined
+    - _firewall_networkmanager_service_running.status.ActiveState == 'active'
+    - _firewall_networkmanager_service_running.status.SubState is defined
+    - _firewall_networkmanager_service_running.status.SubState == 'running'
+  block:
+
+    - name: get current connection name from interface (networkmanager)
+      ansible.builtin.shell:
+        cmd: |-
+          nmcli -t -f name,device connection show --active | \grep ':{{ _nmcli_con_show.interface }}$' | cut -d: -f 1
+      environment:
+        LANG: 'C'
+        LC_ALL: 'C'
+        LC_MESSAGES: 'C'
+        LC_CTYPE: 'C'
+      loop: "{{ firewall_interfaces }}"
+      changed_when: false
+      register: _firewall_current_connection_name
+      loop_control:
+        label: "{{ _nmcli_con_show.interface }}"
+        loop_var: _nmcli_con_show
+
+    - name: add interface to a zone (networkmanager)
+      community.general.nmcli:
+        type: "{{ _conn_name[_conn_name.ansible_loop_var].type | default('ethernet') }}"
+        conn_name: "{{ _conn_name.stdout }}"
+        ifname: "{{ _conn_name[_conn_name.ansible_loop_var].interface }}"
+        zone: "{{ _conn_name[_conn_name.ansible_loop_var].zone }}"
+        state: present
+        # #start# ipv6 workarround for el7
+        dns6_ignore_auto: "{{ true if ansible_os_family == 'RedHat' and ansible_distribution_major_version is version('7', '==') else omit }}"
+        gw6_ignore_auto: "{{ true if ansible_os_family == 'RedHat' and ansible_distribution_major_version is version('7', '==') else omit }}"
+        # #end# ipv6 workarround for el7
+      loop: "{{ _firewall_current_connection_name.results }}"
+      register: _firewall_interface_zone_assignments
+      when:
+        - _conn_name[_conn_name.ansible_loop_var].state is undefined or ( _conn_name[_conn_name.ansible_loop_var].state is defined and _conn_name[_conn_name.ansible_loop_var].state == "enabled" )
+      loop_control:
+        label: "{{ _conn_name[_conn_name.ansible_loop_var].interface }}"
+        loop_var: _conn_name
+      notify: restart NetworkManager
+
+    - name: add interface to a zone (firewalld-interface)
+      ansible.posix.firewalld:
+        zone: "{{ item[item.ansible_loop_var][item[item.ansible_loop_var].ansible_loop_var].zone }}"
+        interface: "{{ item[item.ansible_loop_var][item[item.ansible_loop_var].ansible_loop_var].interface }}"
+        permanent: yes
+        state: enabled
+      loop: "{{ _firewall_interface_zone_assignments.results }}"
+      when:
+        - item[item.ansible_loop_var][item[item.ansible_loop_var].ansible_loop_var].state is undefined or ( item[item.ansible_loop_var][item[item.ansible_loop_var].ansible_loop_var].state is defined and item[item.ansible_loop_var][item[item.ansible_loop_var].ansible_loop_var].state == "enabled" )
+      loop_control:
+        label: "{{ item[item.ansible_loop_var][item[item.ansible_loop_var].ansible_loop_var].interface }}"
+      notify: reload firewalld
+
+    - name: remove interface from a zone (firewalld-interface)
+      ansible.posix.firewalld:
+        zone: "{{ item[item.ansible_loop_var][item[item.ansible_loop_var].ansible_loop_var].zone }}"
+        interface: "{{ item[item.ansible_loop_var][item[item.ansible_loop_var].ansible_loop_var].interface }}"
+        permanent: yes
+        state: disabled
+      loop: "{{ _firewall_interface_zone_assignments.results }}"
+      when:
+        - item[item.ansible_loop_var][item[item.ansible_loop_var].ansible_loop_var].state is defined
+        - item[item.ansible_loop_var][item[item.ansible_loop_var].ansible_loop_var].state == "disabled"
+      loop_control:
+        label: "{{ item[item.ansible_loop_var][item[item.ansible_loop_var].ansible_loop_var].interface }}"
+      notify: reload firewalld

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -13,6 +13,8 @@ _firewall_packages:
     RedHat: []
     Fedora:
       - ufw
+    Suse:
+      - ufw
     openSUSE Leap:
       - ufw
   required:
@@ -23,12 +25,13 @@ _firewall_packages:
     RedHat-7:
       - firewalld
       - iptables
-      - iptables-services
     RedHat:
       - firewalld
     Fedora:
       - firewalld
       - python3-firewall
+    Suse:
+      - firewalld
     openSUSE Leap:
       - firewalld
 
@@ -36,17 +39,29 @@ firewall_packages_conflicting: "{{ _firewall_packages['conflicting'][ansible_dis
 
 firewall_packages_required: "{{ _firewall_packages['required'][ansible_distribution ~ '-' ~ ansible_distribution_major_version] | default(_firewall_packages['required'][ansible_os_family] | default(_firewall_packages['required']['default'] )) }}"
 
+# On CentOS 8 and Fedora >=29 like systems, the requirements can be met by installing the following packages: NetworkManager.
+# On CentOS 7 and Fedora <=28 like systems, the requirements can be met by installing the following packages: NetworkManager-tui.
+# #skipped# On Ubuntu and Debian like systems, the requirements can be met by installing the following packages: network-manager
+# #skipped# On openSUSE, the requirements can be met by installing the following packages: NetworkManager
+firewall_packages_firewalld_nm_fix: |-
+  [
+  {% if (ansible_os_family    == 'RedHat' and ansible_distribution_major_version is version('7', '=='))
+     or (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('28', '<=')) %}
+      "NetworkManager-tui"
+  {% elif (ansible_os_family    == 'RedHat' and ansible_distribution_major_version is version('8', '=='))
+       or (ansible_os_family    == 'Suse')
+       or (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('29', '>='))  %}
+      "NetworkManager"
+  {% endif %}
+  ]
+
 _firewall_service:
   default: ufw
   Alpine: iptables
-  CentOS-7: firewalld
-  CentOS-8: firewalld
-  RedHat-7: firewalld
-  RedHat-8: firewalld
-  Fedora: firewalld
-  openSUSE Leap: firewalld
+  RedHat: firewalld
+  Suse: firewalld
 
-firewall_service: "{{ _firewall_service[ansible_distribution ~ '-' ~ ansible_distribution_major_version] | default (_firewall_service[ansible_distribution] | default (_firewall_service['default'] )) }}"
+firewall_service: "{{ _firewall_service[ansible_os_family] | default (_firewall_service['default'] ) }}"
 
 _firewall_iptables_rulefile:
   Alpine: /etc/iptables/rules-save


### PR DESCRIPTION
Fixes #4

---
name: Pull request
about: Describe the proposed change

---

**Describe the change**
This patch allows to add an interface to a selected zone only on operating systems with firewalld. There is a new list variable `firewall_interfaces`. Example usage:

    - role: ansible-role-firewall
      firewall_interfaces:
        - interface: eth0
          zone: trusted

**Testing**
Tests where done in a new molecule scenario called `physical` (maybe  rename or remove it if there are better options) only on selected operating systems which might be used with firewalld service.
